### PR TITLE
Add network security config for self-signed cert

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,8 +11,9 @@
         android:label="FindBoard"
         android:name="${applicationName}"
         android:icon="@mipmap/launcher_icon"
+        android:enableOnBackInvokedCallback="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:ignore="ExtraText">
-        android:enableOnBackInvokedCallback="true"> <!-- -->
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config>
+        <domain includeSubdomains="true">pe-vnmbd-nvidia-cns.myfiinet.com</domain>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Summary
- add network security config allowing the app to trust a custom certificate for `pe-vnmbd-nvidia-cns.myfiinet.com`
- wire up the config via `android:networkSecurityConfig` in the manifest

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c03647794832aa02db378591e3b3e